### PR TITLE
Use --no-cache for treefmt

### DIFF
--- a/pkgs/linters/treefmt.nix
+++ b/pkgs/linters/treefmt.nix
@@ -6,6 +6,6 @@
   meta = { description = "Run treefmt"; };
   dontBuild = true;
   installPhase = ''
-    ${treefmt}/bin/treefmt --fail-on-change | tee $out
+    ${treefmt}/bin/treefmt --fail-on-change --no-cache | tee $out
   '';
 }


### PR DESCRIPTION
This avoids writing the cache as seemingly newer versions of `treefmt` do:

```
Error: failed to open cache: could not resolve local path for the cache: could not create any of the following paths: [/homeless-shelter/.cache/treefmt/eval-cache]
```